### PR TITLE
Fix enum lookup in wait_for_event

### DIFF
--- a/lib/gphoto2/camera/event.rb
+++ b/lib/gphoto2/camera/event.rb
@@ -30,7 +30,7 @@ module GPhoto2
         rc = gp_camera_wait_for_event(ptr, timeout, type, data_ptr, context.ptr)
         GPhoto2.check!(rc)
 
-        type = CameraEventType[type.read_int]
+        type = FFI::GPhoto2::CameraEventType[type.read_int]
         data = data_ptr.read_pointer
 
         data =


### PR DESCRIPTION
This doesn't include FFI::GPhoto2 so we need to give the full class
name for CameraEventType.