### PR TITLE
Guard against nonexistent CameraOperation key

### DIFF
--- a/lib/gphoto2/camera.rb
+++ b/lib/gphoto2/camera.rb
@@ -151,7 +151,7 @@ module GPhoto2
     # @param [CameraOperation] operation
     # @return [Boolean]
     def can?(operation)
-      (abilities[:operations] & CameraOperation[operation]) != 0
+      (abilities[:operations] & (CameraOperation[operation] || 0)) != 0
     end
 
     private


### PR DESCRIPTION
Fix exception thrown when trying to check for nonexistent `CameraOperation` key (think `camera.can? :capture_nonexistent_feature`):
```
TypeError: nil can't be coerced into Fixnum
from /.../gems/ffi-gphoto2-0.5.1/lib/gphoto2/camera.rb:146:in `&'
```