### PR TITLE
Refactor GPhoto2::Error to use #message with #code

### DIFF
--- a/lib/gphoto2.rb
+++ b/lib/gphoto2.rb
@@ -43,14 +43,13 @@ module GPhoto2
   class Error < RuntimeError
     attr_reader :code
 
-    def initialize(message, code = nil)
+    def initialize(message, code)
       @code = code
       super(message)
     end
 
     def to_s
-      return "#{super} (#{code})" unless code.nil?
-      return super
+      "#{super} (#{code})"
     end
   end
 

--- a/lib/gphoto2.rb
+++ b/lib/gphoto2.rb
@@ -40,7 +40,19 @@ require 'gphoto2/version'
 
 module GPhoto2
   # A runtime error for unsuccessful return codes.
-  class Error < RuntimeError; end
+  class Error < RuntimeError
+    attr_reader :code
+
+    def initialize(message, code = nil)
+      @code = code
+      super(message)
+    end
+
+    def to_s
+      return "#{super} (#{code})" unless code.nil?
+      return super
+    end
+  end
 
   # @return [Logger]
   def self.logger
@@ -53,6 +65,6 @@ module GPhoto2
   def self.check!(rc)
     logger.debug "#{caller.first} => #{rc}" if ENV['DEBUG']
     return if rc >= FFI::GPhoto2Port::GP_OK
-    raise Error, "#{PortResult.as_string(rc)} (#{rc})"
+    raise Error.new PortResult.as_string(rc), rc
   end
 end

--- a/spec/gphoto2_spec.rb
+++ b/spec/gphoto2_spec.rb
@@ -4,8 +4,9 @@ describe GPhoto2 do
   describe '.check!' do
     context 'the return code is not GP_OK' do
       it 'raises GPhoto2::Error with a message and error code' do
-        message = 'Unspecified error (-1)'
-        expect { GPhoto2.check!(-1) }.to raise_error(GPhoto2::Error, message)
+        code = -1
+        message = "Unspecified error (#{code})"
+        expect { GPhoto2.check!(code) }.to raise_error(GPhoto2::Error, message) {|e| expect(e.code).to eq code }
       end
     end
   end


### PR DESCRIPTION
Split previously passed message with error code — `Unspecified error (-1)` into `#message` — `Unspecified error` and `#code` — `-1`, all this without changing `#to_s` semantics