### PR TITLE
Fix Camera#can? to handle devices with no abilities[:operations]

### DIFF
--- a/lib/gphoto2/camera.rb
+++ b/lib/gphoto2/camera.rb
@@ -151,8 +151,7 @@ module GPhoto2
     # @param [CameraOperation] operation
     # @return [Boolean]
     def can?(operation)
-      return false if abilities[:operations] === :none
-      (abilities[:operations] & (CameraOperation[operation] || 0)) != 0
+      (abilities.operations & (CameraOperation[operation] || 0)) != 0
     end
 
     private

--- a/lib/gphoto2/camera.rb
+++ b/lib/gphoto2/camera.rb
@@ -151,6 +151,7 @@ module GPhoto2
     # @param [CameraOperation] operation
     # @return [Boolean]
     def can?(operation)
+      return false if abilities[:operations] === :none
       (abilities[:operations] & (CameraOperation[operation] || 0)) != 0
     end
 

--- a/lib/gphoto2/camera_abilities.rb
+++ b/lib/gphoto2/camera_abilities.rb
@@ -32,8 +32,11 @@ module GPhoto2
 
     # @return [Integer]
     def operations
-      return 0 if self[:operations] === :none
-      self[:operations]
+      if self[:operations] === :none
+        CameraOperation[:none]
+      else
+        self[:operations]
+      end
     end
 
     private

--- a/lib/gphoto2/camera_abilities.rb
+++ b/lib/gphoto2/camera_abilities.rb
@@ -32,7 +32,7 @@ module GPhoto2
 
     # @return [Integer]
     def operations
-      if self[:operations] === :none
+      if self[:operations] == :none
         CameraOperation[:none]
       else
         self[:operations]

--- a/lib/gphoto2/camera_abilities.rb
+++ b/lib/gphoto2/camera_abilities.rb
@@ -30,6 +30,12 @@ module GPhoto2
       ptr[field]
     end
 
+    # @return [Integer]
+    def operations
+      return 0 if self[:operations] === :none
+      self[:operations]
+    end
+
     private
 
     def get_abilities

--- a/spec/gphoto2/camera_spec.rb
+++ b/spec/gphoto2/camera_spec.rb
@@ -127,6 +127,7 @@ module GPhoto2
 
       before do
         allow(camera).to receive_message_chain(:abilities, :[]).and_return(operations)
+        allow(camera.abilities).to receive(:operations).and_return(operations)
       end
 
       context 'when the camera has the ability to perform an operation' do


### PR DESCRIPTION
Fixes below exception, thrown when calling `camera.can? :capture_image` on device like _iPhone_ — which still technically advertises itself as a camera...
```
NoMethodError: undefined method `&' for :none:Symbol
from /.../ffi-gphoto2-0.5.1/lib/gphoto2/camera.rb:146:in `can?'
```