### PR TITLE
Guard against nonexistent Camera#config keys

### DIFF
--- a/lib/gphoto2/camera/configuration.rb
+++ b/lib/gphoto2/camera/configuration.rb
@@ -70,7 +70,8 @@ module GPhoto2
       # @param [Object] value
       # @return [Object]
       def []=(key, value)
-        self[key].value = value
+        return unless option = self[key]
+        option.value = value
         @dirty = true
         value
       end

--- a/lib/gphoto2/camera/configuration.rb
+++ b/lib/gphoto2/camera/configuration.rb
@@ -70,8 +70,8 @@ module GPhoto2
       # @param [Object] value
       # @return [Object]
       def []=(key, value)
-        return unless option = self[key]
-        option.value = value
+        raise ArgumentError, "invalid key: #{key}" unless self[key]
+        self[key].value = value
         @dirty = true
         value
       end


### PR DESCRIPTION
Passing nonexistent key to `Camera#[]=` or `Camera#update` methods results in exception like one below:
```
NoMethodError: undefined method `value=' for nil:NilClass
from /.../ffi-gphoto2-0.5.1/lib/gphoto2/camera/configuration.rb:73:in `[]='
```