### PR TITLE
* add .release to CameraFile

### DIFF
--- a/lib/gphoto2/camera_file.rb
+++ b/lib/gphoto2/camera_file.rb
@@ -52,6 +52,11 @@ module GPhoto2
       preview? ? nil : get_info
     end
 
+    def release
+        FFI::GPhoto2::CameraFile.release(ptr)
+        @ptr = nil
+    end
+    
     private
 
     def data_and_size


### PR DESCRIPTION
sample:


```
device = GPhoto2::Camera.first
while true
    file = device.preview
    data = device.preview.data
    #output data
    #....
    #free memory
    file.release
end

```

without the `.release` this loop produces a memory leak.
i required that as  i am doing the preview pic inside a sinatra app, polling with JS ever 0.5 seconds, was quiet a memory hog!


see also: https://github.com/zaeleus/ffi-gphoto2/issues/13

ping: @zaeleus 