### PR TITLE
Changed the dependency of ffi from 1.9 to 1.12...

### DIFF
--- a/ffi-gphoto2.gemspec
+++ b/ffi-gphoto2.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.5.0'
   spec.add_development_dependency 'yard', '~> 0.9.0'
 
-  spec.add_dependency 'ffi', '~> 1.9.0'
+  spec.add_dependency 'ffi', '~> 1.12.0'
 end


### PR DESCRIPTION
...to avoid the deluge of warnings about rb_safe_level being removed in Ruby 3.

(".../ffi-gphoto2-0.7.1/lib/gphoto2/camera/filesystem.rb:33: warning:
 rb_safe_level will be removed in Ruby 3.0")